### PR TITLE
Make mods crossplatform & fix compatibility with SMAPI 1.0

### DIFF
--- a/BetterRNG/BetterRNG.csproj
+++ b/BetterRNG/BetterRNG.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BetterRNG</RootNamespace>
     <AssemblyName>BetterRNG</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,24 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -65,8 +51,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/BetterRNG/Properties/AssemblyInfo.cs
+++ b/BetterRNG/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/BetterRNG/manifest.json
+++ b/BetterRNG/manifest.json
@@ -3,7 +3,7 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
+    "MinorVersion": 4,
     "PatchVersion": 0,
     "Build": ""
   },

--- a/BetterRNG/packages.config
+++ b/BetterRNG/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/CalendarAnywhere/CalendarAnywhere.csproj
+++ b/CalendarAnywhere/CalendarAnywhere.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CalendarAnywhere</RootNamespace>
     <AssemblyName>CalendarAnywhere</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,24 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -64,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CalendarAnywhere/Properties/AssemblyInfo.cs
+++ b/CalendarAnywhere/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/CalendarAnywhere/manifest.json
+++ b/CalendarAnywhere/manifest.json
@@ -3,7 +3,7 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
+    "MinorVersion": 4,
     "PatchVersion": 0,
     "Build": ""
   },

--- a/CalendarAnywhere/packages.config
+++ b/CalendarAnywhere/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/DurableFences/DurableFences.csproj
+++ b/DurableFences/DurableFences.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DurableFences</RootNamespace>
     <AssemblyName>DurableFences</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,21 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -61,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/DurableFences/Properties/AssemblyInfo.cs
+++ b/DurableFences/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/DurableFences/manifest.json
+++ b/DurableFences/manifest.json
@@ -3,7 +3,7 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
+    "MinorVersion": 4,
     "PatchVersion": 0,
     "Build": ""
   },

--- a/DurableFences/packages.config
+++ b/DurableFences/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/FishingMod/FishingMod.cs
+++ b/FishingMod/FishingMod.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewModdingAPI.Inheritance.Menus;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Tools;

--- a/FishingMod/FishingMod.csproj
+++ b/FishingMod/FishingMod.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="FishingMod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SBobberBar.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json">

--- a/FishingMod/FishingMod.csproj
+++ b/FishingMod/FishingMod.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FishingMod</RootNamespace>
     <AssemblyName>FishingMod</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,21 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -61,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/FishingMod/Properties/AssemblyInfo.cs
+++ b/FishingMod/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/FishingMod/SBobberBar.cs
+++ b/FishingMod/SBobberBar.cs
@@ -1,0 +1,288 @@
+﻿using System.Reflection;
+using Microsoft.Xna.Framework;
+using StardewValley.BellsAndWhistles;
+using StardewValley.Menus;
+
+namespace FishingMod
+{
+    public class SBobberBar : BobberBar
+    {
+        /// <summary>
+        ///     DO NOT CONSTRUCT THIS CLASS
+        ///     To retrieve an instance of SBobberBar, use SBobberBar.ConstructFromBaseClass()
+        /// </summary>
+        public SBobberBar(int whichFish, float fishSize, bool treasure, int bobber) : base(whichFish, fishSize, treasure, bobber)
+        {
+        }
+
+        public BobberBar BaseBobberBar { get; private set; }
+
+        /// <summary>
+        ///     The green rectangle bar that moves up and down
+        /// </summary>
+        public float bobberPosition
+        {
+            get { return (float)GetBaseFieldInfo("bobberPosition").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberPosition").SetValue(BaseBobberBar, value); }
+        }
+
+        /// <summary>
+        ///     The green bar on the right. How close to catching the fish you are
+        ///     Range: 0 - 1 | 1 = catch, 0 = fail
+        /// </summary>
+        public float distanceFromCatching
+        {
+            get { return (float)GetBaseFieldInfo("distanceFromCatching").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("distanceFromCatching").SetValue(BaseBobberBar, value); }
+        }
+
+        public float difficulty
+        {
+            get { return (float)GetBaseFieldInfo("difficulty").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("difficulty").SetValue(BaseBobberBar, value); }
+        }
+
+        public int motionType
+        {
+            get { return (int)GetBaseFieldInfo("motionType").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("motionType").SetValue(BaseBobberBar, value); }
+        }
+
+        public int whichFish
+        {
+            get { return (int)GetBaseFieldInfo("whichFish").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("whichFish").SetValue(BaseBobberBar, value); }
+        }
+
+        public float bobberSpeed
+        {
+            get { return (float)GetBaseFieldInfo("bobberSpeed").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberSpeed").SetValue(BaseBobberBar, value); }
+        }
+
+        public float bobberAcceleration
+        {
+            get { return (float)GetBaseFieldInfo("bobberAcceleration").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberAcceleration").SetValue(BaseBobberBar, value); }
+        }
+
+        public float bobberTargetPosition
+        {
+            get { return (float)GetBaseFieldInfo("bobberTargetPosition").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberTargetPosition").SetValue(BaseBobberBar, value); }
+        }
+
+        public float scale
+        {
+            get { return (float)GetBaseFieldInfo("scale").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("scale").SetValue(BaseBobberBar, value); }
+        }
+
+        public float everythingShakeTimer
+        {
+            get { return (float)GetBaseFieldInfo("everythingShakeTimer").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("everythingShakeTimer").SetValue(BaseBobberBar, value); }
+        }
+
+        public float floaterSinkerAcceleration
+        {
+            get { return (float)GetBaseFieldInfo("floaterSinkerAcceleration").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("floaterSinkerAcceleration").SetValue(BaseBobberBar, value); }
+        }
+
+        public float treasurePosition
+        {
+            get { return (float)GetBaseFieldInfo("treasurePosition").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasurePosition").SetValue(BaseBobberBar, value); }
+        }
+
+        public float treasureCatchLevel
+        {
+            get { return (float)GetBaseFieldInfo("treasureCatchLevel").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasureCatchLevel").SetValue(BaseBobberBar, value); }
+        }
+
+        public float treasureAppearTimer
+        {
+            get { return (float)GetBaseFieldInfo("treasureAppearTimer").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasureAppearTimer").SetValue(BaseBobberBar, value); }
+        }
+
+        public float treasureScale
+        {
+            get { return (float)GetBaseFieldInfo("treasureScale").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasureScale").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool bobberInBar
+        {
+            get { return (bool)GetBaseFieldInfo("bobberInBar").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberInBar").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool buttonPressed
+        {
+            get { return (bool)GetBaseFieldInfo("buttonPressed").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("buttonPressed").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool flipBubble
+        {
+            get { return (bool)GetBaseFieldInfo("flipBubble").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("flipBubble").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool fadeIn
+        {
+            get { return (bool)GetBaseFieldInfo("fadeIn").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("fadeIn").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool fadeOut
+        {
+            get { return (bool)GetBaseFieldInfo("fadeOut").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberPfadeOutosition").SetValue(BaseBobberBar, value); }
+        }
+
+        /// <summary>
+        ///     Whether or not a treasure chest appears
+        /// </summary>
+        public bool treasure
+        {
+            get { return (bool)GetBaseFieldInfo("treasure").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasure").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool treasureCaught
+        {
+            get { return (bool)GetBaseFieldInfo("treasureCaught").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasureCaught").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool perfect
+        {
+            get { return (bool)GetBaseFieldInfo("perfect").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("perfect").SetValue(BaseBobberBar, value); }
+        }
+
+        public bool bossFish
+        {
+            get { return (bool)GetBaseFieldInfo("bossFish").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bossFish").SetValue(BaseBobberBar, value); }
+        }
+
+        public int bobberBarHeight
+        {
+            get { return (int)GetBaseFieldInfo("bobberBarHeight").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberBarHeight").SetValue(BaseBobberBar, value); }
+        }
+
+        public int fishSize
+        {
+            get { return (int)GetBaseFieldInfo("fishSize").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("fishSize").SetValue(BaseBobberBar, value); }
+        }
+
+        public int fishQuality
+        {
+            get { return (int)GetBaseFieldInfo("fishQuality").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("fishQuality").SetValue(BaseBobberBar, value); }
+        }
+
+        public int minFishSize
+        {
+            get { return (int)GetBaseFieldInfo("minFishSize").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("minFishSize").SetValue(BaseBobberBar, value); }
+        }
+
+        public int maxFishSize
+        {
+            get { return (int)GetBaseFieldInfo("maxFishSize").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("maxFishSize").SetValue(BaseBobberBar, value); }
+        }
+
+        public int fishSizeReductionTimer
+        {
+            get { return (int)GetBaseFieldInfo("fishSizeReductionTimer").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("fishSizeReductionTimer").SetValue(BaseBobberBar, value); }
+        }
+
+        public int whichBobber
+        {
+            get { return (int)GetBaseFieldInfo("whichBobber").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("whichBobber").SetValue(BaseBobberBar, value); }
+        }
+
+        public Vector2 barShake
+        {
+            get { return (Vector2)GetBaseFieldInfo("barShake").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("barShake").SetValue(BaseBobberBar, value); }
+        }
+
+        public Vector2 fishShake
+        {
+            get { return (Vector2)GetBaseFieldInfo("fishShake").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("fishShake").SetValue(BaseBobberBar, value); }
+        }
+
+        public Vector2 everythingShake
+        {
+            get { return (Vector2)GetBaseFieldInfo("everythingShake").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("everythingShake").SetValue(BaseBobberBar, value); }
+        }
+
+        public Vector2 treasureShake
+        {
+            get { return (Vector2)GetBaseFieldInfo("treasureShake").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("treasureShake").SetValue(BaseBobberBar, value); }
+        }
+
+        public float reelRotation
+        {
+            get { return (float)GetBaseFieldInfo("reelRotation").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("reelRotation").SetValue(BaseBobberBar, value); }
+        }
+
+        public SparklingText sparkleText
+        {
+            get { return (SparklingText)GetBaseFieldInfo("sparkleText").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("sparkleText").SetValue(BaseBobberBar, value); }
+        }
+
+        public float bobberBarPos
+        {
+            get { return (float)GetBaseFieldInfo("bobberBarPos").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberBarPos").SetValue(BaseBobberBar, value); }
+        }
+
+        public float bobberBarSpeed
+        {
+            get { return (float)GetBaseFieldInfo("bobberBarSpeed").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberBarSpeed").SetValue(BaseBobberBar, value); }
+        }
+
+        public float bobberBarAcceleration
+        {
+            get { return (float)GetBaseFieldInfo("bobberBarAcceleration").GetValue(BaseBobberBar); }
+            set { GetBaseFieldInfo("bobberBarAcceleration").SetValue(BaseBobberBar, value); }
+        }
+
+        public static FieldInfo[] PrivateFields => GetPrivateFields();
+
+        public static SBobberBar ConstructFromBaseClass(BobberBar baseClass)
+        {
+            var b = new SBobberBar(0, 0, false, 0) { BaseBobberBar = baseClass };
+            return b;
+        }
+
+        public static FieldInfo[] GetPrivateFields()
+        {
+            return typeof(BobberBar).GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+
+        public static FieldInfo GetBaseFieldInfo(string name)
+        {
+            return typeof(BobberBar).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        }
+    }
+}

--- a/FishingMod/manifest.json
+++ b/FishingMod/manifest.json
@@ -3,8 +3,8 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
-    "PatchVersion": 1,
+    "MinorVersion": 4,
+    "PatchVersion": 0,
     "Build": ""
   },
   "Description": "Allows you to change some things with fishing based on a config file.",

--- a/FishingMod/packages.config
+++ b/FishingMod/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/HealthBars/HealthBars.csproj
+++ b/HealthBars/HealthBars.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HealthBars</RootNamespace>
     <AssemblyName>HealthBars</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,24 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -55,10 +41,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="xTile">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\xTile.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HealthBars.cs" />
@@ -68,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/HealthBars/Properties/AssemblyInfo.cs
+++ b/HealthBars/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/HealthBars/manifest.json
+++ b/HealthBars/manifest.json
@@ -3,8 +3,8 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
-    "PatchVersion": 1,
+    "MinorVersion": 4,
+    "PatchVersion": 0,
     "Build": ""
   },
   "Description": "Shows monster health bars.",

--- a/HealthBars/packages.config
+++ b/HealthBars/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/JunimoDepositAnywhere/JunimoDepositAnywhere.csproj
+++ b/JunimoDepositAnywhere/JunimoDepositAnywhere.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JunimoDepositAnywhere</RootNamespace>
     <AssemblyName>JunimoDepositAnywhere</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,21 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -61,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/JunimoDepositAnywhere/Properties/AssemblyInfo.cs
+++ b/JunimoDepositAnywhere/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/JunimoDepositAnywhere/manifest.json
+++ b/JunimoDepositAnywhere/manifest.json
@@ -3,7 +3,7 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
+    "MinorVersion": 4,
     "PatchVersion": 0,
     "Build": ""
   },

--- a/JunimoDepositAnywhere/packages.config
+++ b/JunimoDepositAnywhere/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/MovementMod/MovementMod.csproj
+++ b/MovementMod/MovementMod.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MovementMod</RootNamespace>
     <AssemblyName>MovementMod</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,21 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -61,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MovementMod/Properties/AssemblyInfo.cs
+++ b/MovementMod/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/MovementMod/manifest.json
+++ b/MovementMod/manifest.json
@@ -3,7 +3,7 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
+    "MinorVersion": 4,
     "PatchVersion": 0,
     "Build": ""
   },

--- a/MovementMod/packages.config
+++ b/MovementMod/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>

--- a/RegenMod/Properties/AssemblyInfo.cs
+++ b/RegenMod/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/RegenMod/RegenMod.csproj
+++ b/RegenMod/RegenMod.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RegenMod</RootNamespace>
     <AssemblyName>RegenMod</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -29,21 +29,10 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <GamePath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley</GamePath>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Stardew Valley">
-      <HintPath>D:\#Network-Steam\SteamRepo\steamapps\common\Stardew Valley\Stardew Valley.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="StardewModdingAPI">
-      <HintPath>..\StardewModdingAPI.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -61,8 +50,16 @@
     <None Include="manifest.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/RegenMod/manifest.json
+++ b/RegenMod/manifest.json
@@ -3,8 +3,8 @@
   "Authour": "Zoryn",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 3,
-    "PatchVersion": 1,
+    "MinorVersion": 4,
+    "PatchVersion": 0,
     "Build": ""
   },
   "Description": "Allows the player to regen health and stamina based on config values",

--- a/RegenMod/packages.config
+++ b/RegenMod/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.2.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
This pull request...

* adds support for Linux and Mac once SMAPI 1.0 is released (without breaking compatibility with the current SMAPI);
* moves SMAPI's `SBobberBar` class into the fishing mod (since it'll be removed in SMAPI 1.0).

Support for Linux and Mac is added using the [crossplatform mod configuration](https://github.com/Pathoschild/Stardew.ModBuildConfig), which also makes building the mods from source easier (since it auto-detects your game path) and lets you debug the mod when it's running using Visual Studio.