### PR TITLE
Fix unreachable maxValue == minValue condition

### DIFF
--- a/BetterRNG/Framework/MersenneTwister.cs
+++ b/BetterRNG/Framework/MersenneTwister.cs
@@ -142,7 +142,7 @@ namespace BetterRNG.Framework
         /// </exception>
         public override int Next(int minValue, int maxValue)
         {
-            if (maxValue <= minValue)
+            if (maxValue < minValue)
             {
                 throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
SDV's `Farmer.checkDamage` method seems to effectively call `MersenneTwister.Next(0, 0)` when a monster's damage is set to 1, 2, or 3. This throws an ArgumentOutOfRangeException because the twister's `if (maxValue == minValue)` condition is unreachable.

This change allows equal min-max values to avoid the exception throw, at least for this specific method. `NextUInt32(uint minValue, uint maxValue)` may have a similar issue, but I haven't directly tested that.

Note that this mainly affects other mods: SDV's monsters generally have DamageToFarmers  >= 4. Additionally, the exception-throwing call only seems to be made by multiplayer farmhands, never the host.