### PR TITLE
HealthBars: Zoom level and Ui scale modifiers

### DIFF
--- a/HealthBars/ModEntry.cs
+++ b/HealthBars/ModEntry.cs
@@ -59,7 +59,6 @@ namespace HealthBars
 
             SpriteFont font = Game1.smallFont;
             SpriteBatch batch = Game1.spriteBatch;
-            Rectangle viewport = Game1.viewport;
 
             foreach (Monster monster in monsters)
             {
@@ -71,7 +70,8 @@ namespace HealthBars
 
                 Vector2 size = new Vector2(monster.Sprite.SpriteWidth, monster.Sprite.SpriteHeight) * Game1.pixelZoom;
 
-                Vector2 screenLoc = monster.Position - new Vector2(viewport.X, viewport.Y);
+                Vector2 screenLoc = Game1.GlobalToLocal(monster.position);
+                screenLoc *= Game1.options.zoomLevel / Game1.options.uiScale;
                 screenLoc.X += size.X / 2 - this.Config.BarWidth / 2.0f;
                 screenLoc.Y -= this.Config.BarHeight;
 


### PR DESCRIPTION
Based on #26 

This change would correctly show health bar above the enemy if ui scale is different from zoom level (I'm usually playing with ui scale set to 100, and zoom level at 75. In the current version of the mod it makes the health bar appear way off the enemy)